### PR TITLE
Add the scale subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,3 +69,13 @@ $ os-tools update-resource \
   --property-path 'spec.template.spec.containers[0].readinessProbe' \
   --filename 'updated-dep-config.yaml'
 ```
+
+### Scaling applications
+
+To scale all applications from a range of namespaces, you just have to provide the regex and the number of replicas.
+
+```
+$ os-tools scale \
+  --namespace-regex '^project-name-' \
+  --replicas 1
+```

--- a/index.js
+++ b/index.js
@@ -52,4 +52,12 @@ program
   .option('-f, --filename <filename>', 'YAML file')
   .action(options => run('updateResource', options))
 
+program
+  .command('scale')
+  .option('-t, --resource-type <resourceType>', 'resource type')
+  .option('-n, --resource-name <resourceName>', 'resource name')
+  .option('-r, --namespace-regex <namespaceRegex>', 'regular expression to filter the namespace')
+  .option('--replicas <replicas>', 'number of replicas')
+  .action(options => run('scale', options))
+
 program.parse(process.argv)

--- a/lib/commands/scale/index.js
+++ b/lib/commands/scale/index.js
@@ -1,0 +1,18 @@
+#!/usr/bin/env node
+
+const { getNamespacesAliases } = require('../../utils/misc')
+
+module.exports = async (options, { os }) => {
+  try {
+    const { namespaceRegex, replicas } = options
+    const projects = await os.getAllProjects()
+    const namespaces = getNamespacesAliases(projects, namespaceRegex)
+    const namespaceScalePromises = namespaces.map(namespace => {
+      return os.scale(namespace, parseInt(replicas))
+    })
+
+    await Promise.all(namespaceScalePromises)
+  } catch (e) {
+    throw e
+  }
+}

--- a/lib/services/openshift/index.js
+++ b/lib/services/openshift/index.js
@@ -1,3 +1,4 @@
+const { uniq, flatten, cloneDeep } = require('lodash')
 const axios = require('axios')
 const { getTemplate } = require('./templates/index')
 const resourceNameMap = {
@@ -24,7 +25,13 @@ module.exports = class OpenShiftService {
   }
 
   getApplicationsAliases (namespace) {
-    // TODO: get all applications aliases from a namespace
+    const getAliases = response => response.data.items.map(({ metadata }) => metadata.name)
+    const promises = [
+      this.os.get(`oapi/v1/namespaces/${namespace}/buildconfigs`).then(getAliases),
+      this.os.get(`oapi/v1/namespaces/${namespace}/deploymentconfigs`).then(getAliases)
+    ]
+
+    return Promise.all(promises).then(aliases => uniq(flatten(aliases)))
   }
 
   getAllProjects () {
@@ -44,8 +51,23 @@ module.exports = class OpenShiftService {
     )
   }
 
-  scale (namespace, replicas = 1) {
-    // TODO: scale all applications from a namespace
+  async scale (namespace, replicas = 1) {
+    let payload, promises
+    let applicationsAliases = await this.getApplicationsAliases(namespace)
+
+    payload = getTemplate('Scale')
+
+    promises = applicationsAliases.map(alias => {
+      payload = cloneDeep(payload)
+
+      payload.metadata.name = alias
+      payload.metadata.namespace = namespace
+      payload.spec.replicas = replicas
+
+      return this.os.put(`oapi/v1/namespaces/${namespace}/deploymentconfigs/${alias}/scale`, payload)
+    })
+
+    return await Promise.all(promises)
   }
 
   instantiate (namespace, resourceType, resourceName) {

--- a/lib/services/openshift/templates/Scale.yaml
+++ b/lib/services/openshift/templates/Scale.yaml
@@ -1,0 +1,9 @@
+apiVersion: extensions/v1beta1
+kind: Scale
+metadata:
+  name: default
+  namespace: default
+spec:
+  replicas: 0
+status:
+  replicas: 0


### PR DESCRIPTION
With this subcommand, a range of namespaces could have all the applications scaled with the provided number of replicas.