### PR TITLE
Add filters to update-resource subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,3 +112,24 @@ $ os-tools check-resources \
   --resources-names app1 \
   --resources-names app2
 ```
+
+### Generating an environment variables report
+
+To generate a TSV report containing all the namespaces that contains some environment variable, you can use the following subcommand:
+
+```
+$ os-tools check-env \
+  --resource-type build \
+  --namespace-regex '^project-name-' \
+  --variable SOME_VARIABLE
+```
+
+### Searching namespaces by external route
+
+To find a namespace by route, you can use the following subcommand:
+
+```
+$ os-tools check-env \
+  --namespace-regex '^project-name-' \
+  --hostname example.com
+```

--- a/index.js
+++ b/index.js
@@ -76,6 +76,7 @@ program
   .option('-r, --namespace-regex <namespaceRegex>', 'regular expression to filter the namespace')
   .option('--user <user>', 'user name')
   .option('--role <role>', 'project role')
+  .option('--revoke', 'revoke permission')
   .action(options => run('membership', options))
 
 program

--- a/index.js
+++ b/index.js
@@ -86,6 +86,16 @@ program
   .option('--environment-alias <environmentAlias>', 'environment alias')
   .action(options => run('checkResources', options))
 
+program
+  .command('check-env')
+  .option('-t, --resource-type <resourceType>', 'resource type')
+  .option('-r, --namespace-regex <namespaceRegex>', 'regular expression to filter the namespace')
+  .option('-v, --variable <variable>', 'variable (value)', collect, [])
+  .option('--search-by-value', 'search by value instead of name')
+  .option('--whole-word', 'search for the exact term')
+  .option('--environment-alias <environmentAlias>', 'environment alias')
+  .action(options => run('checkEnv', options))
+
 program.parse(process.argv)
 
 if (!program.args.length) program.outputHelp()

--- a/index.js
+++ b/index.js
@@ -31,6 +31,7 @@ program
   .option('-r, --namespace-regex <namespaceRegex>', 'regular expression to filter the namespace')
   .option('--ignore <ignoredNamespace>', 'namespaces to ignore', collect, [])
   .option('-v, --variable <variable>', 'variable with name and value', collect, [])
+  .option('--environment-alias <environmentAlias>', 'environment alias')
   .action(options => run('setEnv', options))
 
 program
@@ -40,6 +41,7 @@ program
   .option('-r, --namespace-regex <namespaceRegex>', 'regular expression to filter the namespace')
   .option('--ignore <ignoredNamespace>', 'namespaces to ignore', collect, [])
   .option('-s, --source-ref [sourceRef]', 'tag/branch/commit hash from Git')
+  .option('--environment-alias <environmentAlias>', 'environment alias')
   .action(options => run('instantiate', options))
 
 program
@@ -57,6 +59,7 @@ program
   .option('-r, --namespace-regex <namespaceRegex>', 'regular expression to filter the namespace')
   .option('-n, --resources-names <resourcesNames>', 'resources names', collect, [])
   .option('--ignore <ignoredNamespace>', 'namespaces to ignore', collect, [])
+  .option('--environment-alias <environmentAlias>', 'environment alias')
   .option('--replicas <replicas>', 'number of replicas')
   .action(options => run('scale', options))
 
@@ -79,6 +82,7 @@ program
   .command('check-resources')
   .option('-r, --namespace-regex <namespaceRegex>', 'regular expression to filter the namespace')
   .option('-n, --resources-names <resourcesNames>', 'resources names', collect, [])
+  .option('--environment-alias <environmentAlias>', 'environment alias')
   .action(options => run('checkResources', options))
 
 program.parse(process.argv)

--- a/index.js
+++ b/index.js
@@ -96,6 +96,13 @@ program
   .option('--environment-alias <environmentAlias>', 'environment alias')
   .action(options => run('checkEnv', options))
 
+program
+  .command('check-route')
+  .option('-r, --namespace-regex <namespaceRegex>', 'regular expression to filter the namespace')
+  .option('--hostname <hostname>', 'hostname')
+  .option('--environment-alias <environmentAlias>', 'environment alias')
+  .action(options => run('checkRoute', options))
+
 program.parse(process.argv)
 
 if (!program.args.length) program.outputHelp()

--- a/lib/commands/checkEnv/index.js
+++ b/lib/commands/checkEnv/index.js
@@ -1,0 +1,57 @@
+#!/usr/bin/env node
+
+const { writeFileSync } = require('fs')
+const { join } = require('path')
+const { getVariableList } = require('../../utils/misc')
+const moment = require('moment')
+
+module.exports = async (options, { os, ns }) => {
+  try {
+    const { resourceType, variable, searchByValue, wholeWord } = options
+    const namespaces = ns.namespaceList
+    const configPromises = namespaces.map(namespace => {
+      return os.getResource(namespace, resourceType)
+    })
+    const configurations = await Promise.all(configPromises)
+    const searchType = searchByValue ? 'value' : 'name'
+    const output = []
+    let fileContents = ''
+
+    configurations.forEach(({ data: configList }) => {
+      configList.items.forEach(resource => {
+        const variableList = getVariableList(resource, variable, searchType, wholeWord)
+
+        if (variableList.length) {
+          output.push({
+            namespace: resource.metadata.namespace,
+            resourceName: resource.metadata.name,
+            variables: variableList
+          })
+        }
+      })
+    })
+
+    if (!output.length) {
+      throw new Error('No results found.')
+    }
+
+    fileContents += ['Namespace', 'Name', 'Variable'].join('\t') + '\n'
+    fileContents += output.map(({ namespace, resourceName, variables }) => {
+      return [
+        namespace,
+        resourceName,
+        variables.map(e => `${e.name}=${e.value}`).join(',')
+      ].join('\t')
+    }).join('\n')
+
+    writeFileSync(
+      join(
+        process.cwd(),
+        `${resourceType}_summary_${moment().unix()}.tsv`
+      ),
+      fileContents
+    )
+  } catch (e) {
+    throw e
+  }
+}

--- a/lib/commands/checkRoute/index.js
+++ b/lib/commands/checkRoute/index.js
@@ -1,0 +1,38 @@
+#!/usr/bin/env node
+
+const Table = require('cli-table')
+
+module.exports = async (options, { os, ns }) => {
+  try {
+    const { hostname } = options
+    const namespaces = ns.namespaceList
+    const configPromises = namespaces.map(namespace => {
+      return os.getResource(namespace, 'route')
+    })
+    const configurations = await Promise.all(configPromises)
+    const routeResources = configurations
+      .filter(({ data: routeList }) => routeList.items.map(e => e.spec.host).indexOf(hostname) > -1)
+      .map(({ data: routeList }) => routeList.items.find(e => e.spec.host === hostname))
+    const table = new Table({
+      head: ['Project', 'Service Name', 'IET Policy', 'Port'],
+      colWidths: [38, 38, 32, 32]
+    })
+
+    if (!routeResources.length) {
+      throw new Error('The hostname was not found.')
+    }
+
+    routeResources.forEach(({ metadata, spec }) => {
+      table.push([
+        metadata.namespace,
+        spec.to.name,
+        spec.tls ? spec.tls.insecureEdgeTerminationPolicy : 'N/A',
+        spec.port.targetPort
+      ])
+    })
+
+    process.stdout.write(`${table.toString()}\n`)
+  } catch (e) {
+    throw e
+  }
+}

--- a/lib/commands/membership/index.js
+++ b/lib/commands/membership/index.js
@@ -2,17 +2,18 @@
 
 const validUserRoles = [
   'admin',
-  'baisc-user',
+  'basic-user',
   'edit',
-  'view'
+  'view',
+  'all'
 ]
 
 module.exports = async (options, { os, ns }) => {
   try {
-    const { user, role } = options
+    const { user, role, revoke } = options
     const namespaces = ns.namespaceList
     const membershipPromises = namespaces.map(namespace => {
-      return os.addProjectMember(namespace, user, role)
+      return os.updateMembership(namespace, user, role, revoke)
     })
 
     if (validUserRoles.indexOf(role) < 0) {

--- a/lib/services/openshift/index.js
+++ b/lib/services/openshift/index.js
@@ -156,20 +156,71 @@ module.exports = class OpenShiftService {
     })
   }
 
-  addProjectMember (namespace, user, role) {
-    const payload = getTemplate('RoleBinding')
+  updateMembership (namespace, user, role, revoke = false) {
+    return this.os.get(`oapi/v1/namespaces/${namespace}/rolebindings`)
+      .then(({ data: membershipList }) => {
+        let currentRoleObject = membershipList.items.find(e => e.roleRef.name === role) || getTemplate('RoleBinding')
+        let createPermission = false
+        let permissionExists
 
-    payload.metadata = {
-      namespace,
-      generateName: `${role}-`
-    }
-    payload.roleRef.name = role
-    payload.subjects.push({
-      name: user,
-      kind: 'User'
-    })
+        if (!currentRoleObject.roleRef.name) {
+          createPermission = true
 
-    return this.os.post(`oapi/v1/namespaces/${namespace}/rolebindings`, payload)
+          currentRoleObject.roleRef.name = role
+          currentRoleObject.metadata.namespace = namespace
+          currentRoleObject.metadata.generateName = `${role}-`
+          currentRoleObject.userNames = []
+        }
+
+        permissionExists = Boolean(currentRoleObject.subjects.find(e => e.name === user)) &&
+          currentRoleObject.roleRef.name === role
+
+        if (permissionExists) {
+          if (revoke) {
+            currentRoleObject.subjects = currentRoleObject.subjects
+              .filter(e => e.name !== user)
+            currentRoleObject.userNames = currentRoleObject.userNames
+              .filter(e => e !== user)
+
+            if (currentRoleObject.subjects.length > 0) {
+              return this.os.put(
+                `oapi/v1/namespaces/${namespace}/rolebindings/${role}`,
+                currentRoleObject
+              ).catch(e => e)
+            } else {
+              return this.os.delete(
+                `apis/rbac.authorization.k8s.io/v1/namespaces/${namespace}/rolebindings/${currentRoleObject.metadata.name}`,
+                { apiVersion: 'v1', kind: 'DeleteOptions', propagationPolicy: 'Foreground' }
+              ).catch(e => e)
+            }
+          } else {
+            return Promise.resolve()
+          }
+        } else {
+          currentRoleObject.userNames.push(user)
+          currentRoleObject.subjects.push({
+            name: user,
+            kind: 'User'
+          })
+
+          if (createPermission) {
+            return this.os.post(
+              `oapi/v1/namespaces/${namespace}/rolebindings`,
+              currentRoleObject
+            ).catch(e => e)
+          } else {
+            currentRoleObject.apiVersion = 'rbac.authorization.k8s.io/v1'
+            currentRoleObject.kind = 'RoleBinding'
+            currentRoleObject.roleRef.kind = 'ClusterRole'
+            currentRoleObject.roleRef.apiGroup = 'rbac.authorization.k8s.io'
+
+            return this.os.put(
+              `apis/rbac.authorization.k8s.io/v1/namespaces/${namespace}/rolebindings/${currentRoleObject.metadata.name}`,
+              currentRoleObject
+            ).catch(e => e)
+          }
+        }
+      })
   }
 
   checkResources (namespace, resourceName) {

--- a/lib/services/openshift/index.js
+++ b/lib/services/openshift/index.js
@@ -39,7 +39,7 @@ module.exports = class OpenShiftService {
     return this.os.get('oapi/v1/projects').then(({ data }) => data.items)
   }
 
-  getResource (namespace, resourceType, resourceName) {
+  getResource (namespace, resourceType, resourceName = '') {
     return this.os.get(
       `oapi/v1/namespaces/${namespace}/${resourceNameMap[resourceType]}/${resourceName}`
     )

--- a/lib/utils/misc.js
+++ b/lib/utils/misc.js
@@ -1,5 +1,6 @@
 const { readFileSync } = require('fs')
 const yaml = require('js-yaml')
+const { get } = require('lodash')
 
 module.exports = {
   getNamespacesAliases: (projects, namespaceRegex) => {
@@ -36,5 +37,27 @@ module.exports = {
     }
 
     return resourceNameMap[alias]
+  },
+  getVariableList (resource, subjects, searchBy = 'name', wholeWord = false) {
+    const variableList = get(resource, 'spec.strategy.sourceStrategy.env') ||
+      get(resource, 'spec.template.spec.containers[0].env')
+
+    if (!variableList) return []
+
+    return variableList.filter(entry => {
+      return searchBy === 'value'
+        ? wholeWord
+          ? subjects.indexOf(entry.value) > -1
+          : subjects.reduce((acc, subject) => {
+            if (entry.value && entry.value.includes(subject)) acc++
+            return acc
+          }, 0) > 0
+        : wholeWord
+          ? subjects.indexOf(entry.name) > -1
+          : subjects.reduce((acc, subject) => {
+            if (entry.value && entry.name.includes(subject)) acc++
+            return acc
+          }, 0) > 0
+    })
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "os-tools",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "os-tools",
-  "version": "0.3.4",
+  "version": "0.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "os-tools",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "os-tools",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -238,9 +238,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.10",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
+      "version": "4.17.11",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
     },
     "mimic-fn": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "os-tools",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "os-tools",
-  "version": "0.3.4",
+  "version": "0.4.0",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "os-tools",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "",
   "main": "index.js",
   "scripts": {
@@ -18,7 +18,7 @@
     "inquirer": "^6.2.0",
     "js-yaml": "^3.12.0",
     "jsondiffpatch": "^0.3.11",
-    "lodash": "^4.17.10",
+    "lodash": "^4.17.11",
     "moment": "^2.22.2",
     "moment-duration-format": "^2.2.2",
     "queue": "^4.5.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "os-tools",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
The `update-resource` subcommand should now accept parameters fo filter the Kubernetes resources it will alter. For example, you can pass a path and a search term to alter only the resources that matches these criteria.